### PR TITLE
fix(redis): add password authentication support for BullMQ connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DATABASE_URL="postgresql://user:password@localhost:5432/allplatformpost?schema=p
 # Redis
 REDIS_HOST="localhost"
 REDIS_PORT=6379
+REDIS_PASSWORD=""
 
 # Encryption (Generate with: openssl rand -hex 32)
 ENCRYPTION_KEY="your-64-char-hex-key-here"

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -30,6 +30,7 @@ import { MediaModule } from './modules/media/media.module';
       connection: {
         host: process.env.REDIS_HOST || 'localhost',
         port: parseInt(process.env.REDIS_PORT || '6379'),
+        password: process.env.REDIS_PASSWORD || undefined,
       },
     }),
 


### PR DESCRIPTION
## Summary
- Added `REDIS_PASSWORD` environment variable support to BullMQ connection configuration
- Updated `.env.example` with the new `REDIS_PASSWORD` field
- Fixes `NOAUTH Authentication required` error when deploying to Zeabur

## Test plan
- [ ] Verify Redis connection works locally without password (empty string)
- [ ] Deploy to Zeabur with `REDIS_PASSWORD` environment variable set
- [ ] Confirm no NOAUTH errors in runtime logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)