### PR TITLE
Add staging environment with separate deployment pipeline

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-meadow-09650f810.yml
+++ b/.github/workflows/azure-static-web-apps-brave-meadow-09650f810.yml
@@ -4,17 +4,25 @@ on:
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
+      - staging
 
 jobs:
-  build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+  # ── Staging deployment ──────────────────────────────────────────────────────
+  # Triggered by: push to staging, or PRs targeting staging
+  deploy_staging:
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/staging') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'staging' && github.event.action != 'closed') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/staging')
     runs-on: ubuntu-latest
-    name: Build and Deploy Job
+    name: Deploy to Staging
+    environment: staging
     permissions:
       contents: read
       pull-requests: write
@@ -40,13 +48,12 @@ jobs:
       - name: Generate Prisma client
         run: cd v2 && npx prisma generate
 
-      - name: Build Next.js
+      - name: Build Next.js (staging)
         env:
-          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL_STAGING }}
         run: cd v2 && pnpm build
 
-      - name: Deploy to Azure Static Web Apps
-        id: builddeploy
+      - name: Deploy to Azure Static Web Apps (staging)
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_MEADOW_09650F810 }}
@@ -56,14 +63,68 @@ jobs:
           api_location: ""
           output_location: ".next"
           skip_app_build: true
+          # Named staging environment — gets a persistent URL separate from production
+          deployment_environment: staging
 
+  # ── Production deployment ───────────────────────────────────────────────────
+  # Triggered by: push to main, or PRs targeting main
+  deploy_production:
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' && github.event.action != 'closed') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    name: Deploy to Production
+    environment: production
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          lfs: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: v2/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd v2 && pnpm install
+
+      - name: Generate Prisma client
+        run: cd v2 && npx prisma generate
+
+      - name: Build Next.js (production)
+        env:
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+        run: cd v2 && pnpm build
+
+      - name: Deploy to Azure Static Web Apps (production)
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_MEADOW_09650F810 }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "/v2"
+          api_location: ""
+          output_location: ".next"
+          skip_app_build: true
+          # No deployment_environment = production slot
+
+  # ── Close PR preview environments ──────────────────────────────────────────
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
-    name: Close Pull Request Job
+    name: Close Pull Request
     steps:
       - name: Close Pull Request
-        id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BRAVE_MEADOW_09650F810 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - staging
   pull_request:
     branches:
       - main
+      - staging
 
 jobs:
   test:

--- a/.github/workflows/deploy-timer.yml
+++ b/.github/workflows/deploy-timer.yml
@@ -2,14 +2,20 @@ name: Deploy Timer Function
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - staging
     paths:
       - 'v2/timer-function/**'
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  # ── Staging timer function ──────────────────────────────────────────────────
+  deploy_staging_timer:
+    if: github.ref == 'refs/heads/staging' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/staging')
     runs-on: ubuntu-latest
+    name: Deploy Timer (Staging)
+    environment: staging
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +31,48 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Set function app settings
+      - name: Set staging function app settings
+        env:
+          TIMER_FUNCTION_NAME: ${{ secrets.AZURE_TIMER_FUNCTION_NAME_STAGING }}
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          SCHEDULER_APP_URL: ${{ secrets.SCHEDULER_APP_URL_STAGING }}
+          SCHEDULER_API_KEY: ${{ secrets.SCHEDULER_API_KEY_STAGING || secrets.SCHEDULER_API_KEY }}
+        run: |
+          az functionapp config appsettings set \
+            --name "$TIMER_FUNCTION_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --settings \
+              SCHEDULER_APP_URL="$SCHEDULER_APP_URL" \
+              SCHEDULER_API_KEY="$SCHEDULER_API_KEY"
+
+      - name: Deploy to Azure Functions (staging)
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ secrets.AZURE_TIMER_FUNCTION_NAME_STAGING }}
+          package: v2/timer-function
+
+  # ── Production timer function ───────────────────────────────────────────────
+  deploy_production_timer:
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    name: Deploy Timer (Production)
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install and build
+        run: cd v2/timer-function && npm install && npm run build
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set production function app settings
         env:
           TIMER_FUNCTION_NAME: ${{ secrets.AZURE_TIMER_FUNCTION_NAME }}
           RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
@@ -39,7 +86,7 @@ jobs:
               SCHEDULER_APP_URL="$SCHEDULER_APP_URL" \
               SCHEDULER_API_KEY="$SCHEDULER_API_KEY"
 
-      - name: Deploy to Azure Functions
+      - name: Deploy to Azure Functions (production)
         uses: Azure/functions-action@v1
         with:
           app-name: ${{ secrets.AZURE_TIMER_FUNCTION_NAME }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,55 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 All-Platform-Post is a multi-platform social media automation system for publishing content to Facebook, Instagram, Twitter/X, and Threads. Features intelligent character-count splitting, OAuth authentication, scheduled publishing, and media handling.
 
 **Current deployment architecture:**
-- **Frontend**: GitHub Pages (Next.js static export via `Ray05202006.github.io`)
-- **Backend**: Azure Functions (NestJS wrapped in Azure HTTP trigger)
-- **Scheduling**: DB-based scheduler polled by Azure Timer Trigger (no Redis/BullMQ required)
+- **Frontend**: Azure Static Web Apps (Next.js) — production + staging named environments
+- **Scheduling**: Azure Timer Trigger (polls DB every minute for due scheduled posts)
+- **Database**: PostgreSQL (Azure Database / local Docker)
+
+## Branch Strategy (Staging → Production Gate)
+
+**All changes must pass through staging before production.**
+
+```
+feature/xxx  →  PR to staging  →  merge  →  staging deploy  →  test  →  PR to main  →  production deploy
+```
+
+| Branch | Deploys to | Azure SWA environment |
+|--------|------------|----------------------|
+| `staging` | Staging (persistent) | named environment `staging` |
+| `main` | Production | production slot |
+| Feature PR to `staging` | PR preview | auto `pr-NNN` |
+| Staging PR to `main` | PR preview | auto `pr-NNN` |
+
+### Development Workflow
+
+1. Create feature branch from `staging`
+2. Open PR targeting **`staging`** → CI runs + Azure SWA creates a PR preview URL
+3. Merge to `staging` → deploys to staging environment
+4. Test manually on the staging URL
+5. When stable: open PR `staging` → `main` → deploys PR preview for final check
+6. Merge to `main` → deploys to production
+
+### Required GitHub Secrets for Staging
+
+In addition to existing production secrets, add these:
+
+| Secret | Description |
+|--------|-------------|
+| `NEXT_PUBLIC_APP_URL_STAGING` | Staging Azure SWA URL (set after first staging deploy) |
+| `AZURE_TIMER_FUNCTION_NAME_STAGING` | Staging Azure Function App name |
+| `SCHEDULER_APP_URL_STAGING` | Staging app URL for timer to call (same as staging SWA URL + `/api/scheduler/process`) |
+| `SCHEDULER_API_KEY_STAGING` | (Optional) Separate API key for staging scheduler; falls back to `SCHEDULER_API_KEY` |
+
+### Recommended GitHub Environment Protection Rules
+
+Configure in **Settings → Environments**:
+- `staging` environment: no restrictions (auto-deploys on merge)
+- `production` environment: add **Required reviewers** to require manual approval before production deploys
+
+### Staging Azure Resources to Create
+
+1. **Azure Static Web Apps** — same resource supports named environments; no new resource needed
+2. **Azure Function App** (staging timer) — create a separate function app (e.g. `all-platform-post-timer-staging`)
 
 ## Commands
 


### PR DESCRIPTION
## Summary
Implements a complete staging environment with separate CI/CD pipelines for both Azure Static Web Apps and Azure Functions, enabling a staging → production gate workflow as documented in CLAUDE.md.

## Key Changes

### GitHub Actions Workflows
- **azure-static-web-apps-brave-meadow-09650f810.yml**
  - Split single `build_and_deploy_job` into two separate jobs: `deploy_staging` and `deploy_production`
  - Added `staging` branch to push and pull_request triggers
  - Each job now has explicit condition logic to run only on its target branch
  - Staging job uses `NEXT_PUBLIC_APP_URL_STAGING` secret and deploys to named `staging` environment
  - Production job uses `NEXT_PUBLIC_APP_URL` secret and deploys to production slot
  - Added `environment: staging` and `environment: production` to respective jobs for GitHub environment protection
  - Improved job naming and added section comments for clarity

- **deploy-timer.yml**
  - Split single `build-and-deploy` job into `deploy_staging_timer` and `deploy_production_timer`
  - Added `staging` branch to push trigger
  - Each job conditionally runs based on branch ref
  - Staging job uses `AZURE_TIMER_FUNCTION_NAME_STAGING` and staging-specific secrets
  - Production job uses existing `AZURE_TIMER_FUNCTION_NAME` secret
  - Added `environment: staging` and `environment: production` for consistency

- **ci.yml**
  - Added `staging` branch to push and pull_request triggers for lint/test jobs

### Documentation
- **CLAUDE.md**
  - Updated deployment architecture to reflect Azure Static Web Apps with named environments
  - Added comprehensive "Branch Strategy (Staging → Production Gate)" section with workflow diagram
  - Documented required GitHub secrets for staging environment
  - Added recommended GitHub environment protection rules
  - Listed staging Azure resources to create

## Implementation Details

- **Conditional job execution**: Uses GitHub Actions expressions (`github.ref`, `github.base_ref`) to route deployments to correct environment
- **Named environments**: Staging uses Azure SWA's named `staging` environment for persistent preview URL; production uses default slot
- **Secret management**: Staging jobs reference `*_STAGING` suffixed secrets, allowing independent configuration
- **Fallback logic**: Timer function staging scheduler API key falls back to production key if staging-specific secret not set
- **PR preview support**: Both staging and production jobs handle PR events, creating auto-generated preview URLs for testing before merge

## Required Setup

Before merging, configure:
1. GitHub Secrets: `NEXT_PUBLIC_APP_URL_STAGING`, `AZURE_TIMER_FUNCTION_NAME_STAGING`, `SCHEDULER_APP_URL_STAGING`, `SCHEDULER_API_KEY_STAGING` (optional)
2. GitHub Environments: Create `staging` and `production` environments in repository settings
3. Azure resources: Create staging Azure Function App for timer trigger

https://claude.ai/code/session_01NgrQ3XtsUcL5hjeC2mgBa8